### PR TITLE
fix : header 에서 userData를 Client에서 fetch하는 것이 아니라 서버 컴포넌트에서 내려주는 로직으로 수정

### DIFF
--- a/app/api/notification/route.ts
+++ b/app/api/notification/route.ts
@@ -24,6 +24,7 @@ export async function GET(request: NextRequest) {
         message: '로그인 토큰이 존재하지 않습니다.',
         data: defaultData,
         nextCursor: null,
+        noReadCount: 0,
       },
       { status: 403 },
     );
@@ -41,6 +42,7 @@ export async function GET(request: NextRequest) {
           message: '사용자 식별 아이디가 존재하지 않습니다.',
           data: defaultData,
           nextCursor: null,
+          noReadCount: 0,
         },
         { status: 403 },
       );
@@ -54,6 +56,7 @@ export async function GET(request: NextRequest) {
           message: '로그인 토큰이 만료되었습니다.',
           data: defaultData,
           nextCursor: null,
+          noReadCount: 0,
         },
         { status: 403 },
       );
@@ -63,6 +66,7 @@ export async function GET(request: NextRequest) {
       message: '로그인 토큰 검증 중 오류가 발생했습니다.',
       data: defaultData,
       nextCursor: null,
+      noReadCount: 0,
     });
   }
 
@@ -80,6 +84,7 @@ export async function GET(request: NextRequest) {
         message: '사용자 데이터가 존재하지 않습니다.',
         data: defaultData,
         nextCursor: null,
+        noReadCount: 0,
       });
     }
 
@@ -91,6 +96,7 @@ export async function GET(request: NextRequest) {
           message: '탈퇴한 유저입니다.',
           data: defaultData,
           nextCursor: null,
+          noReadCount: 0,
         },
         { status: 403 },
       );
@@ -131,12 +137,21 @@ export async function GET(request: NextRequest) {
       nextCursor = nextSnapshot.size > 0 ? String(page + NOTI_LIMIT) : null;
     }
 
+    // 읽지 않은 알림 개수 가져오기
+    const noReadCountSnapshot = await adminDB
+      .collection('notifications')
+      .where('userId', '==', uid)
+      .where('isRead', '==', false)
+      .get();
+    const noReadCount = noReadCountSnapshot.size;
+
     // 최종 데이터 구성
     return typedJson<INotificationResponseData>({
       response: 'ok',
       message: '알림 데이터 조회 성공',
       data: notificationsData,
       nextCursor,
+      noReadCount,
     });
   } catch (error) {
     console.error('Error fetching notification data:', error);
@@ -145,6 +160,7 @@ export async function GET(request: NextRequest) {
       message: '알림 데이터를 가져오는 중 오류가 발생했습니다.',
       data: defaultData,
       nextCursor: null,
+      noReadCount: 0,
     });
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,13 +3,16 @@ import './globals.css';
 import type { Metadata } from 'next';
 import dynamic from 'next/dynamic';
 import localFont from 'next/font/local';
+import { cookies } from 'next/headers';
 import Script from 'next/script';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
 import { Suspense } from 'react';
 import { ToastContainer } from 'react-toastify';
 
-import { QueryProvider } from '@/src/app/providers/query-provider';
+import QueryProvider from '@/src/app/providers/query-provider';
 import { ThemeProvider } from '@/src/app/providers/theme-provider';
+import type { IUserResponseData } from '@/src/shared/types';
+import { fetcher } from '@/src/shared/utils/fetcher.client';
 import { EventModal } from '@/src/widgets/event/ui/EventModal';
 import { Header } from '@/src/widgets/header';
 
@@ -33,11 +36,19 @@ export const metadata: Metadata = {
   },
 };
 
-export default function Layout({
+export default async function Layout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const cookieStore = cookies();
+  const userData = await fetcher<IUserResponseData>('/api/user', {
+    cache: 'no-cache',
+    headers: {
+      Cookie: cookieStore.toString(),
+    },
+  });
+
   return (
     <>
       <html className={`${pretendard.variable} font-pretendard`} lang="ko" suppressHydrationWarning>
@@ -46,10 +57,8 @@ export default function Layout({
             <ThemeProvider attribute="class" defaultTheme="system" disableTransitionOnChange enableSystem>
               <NuqsAdapter>
                 <QueryProvider>
-                  <Header />
-                  <Suspense fallback={null}>
-                    <EventModal />
-                  </Suspense>
+                  <Header userData={userData.userData} />
+                  <EventModal />
                   <main>{children}</main>
                 </QueryProvider>
               </NuqsAdapter>

--- a/src/app/providers/query-provider.tsx
+++ b/src/app/providers/query-provider.tsx
@@ -1,9 +1,30 @@
-'use client';
+'use client'; // QueryClientProvider가 useContext를 쓰므로 필수
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { isServer, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-const queryClient = new QueryClient();
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      // hydration시 staleTime이 0이면 서버에서 가져온 데이터가 바로 stale이 되어버림 -> 20초로 설정
+      queries: { staleTime: 20 * 1000 },
+    },
+  });
+}
 
-export function QueryProvider({ children }: { children: React.ReactNode }) {
+let browserQueryClient: QueryClient | undefined = undefined;
+
+function getQueryClient() {
+  if (isServer) {
+    return makeQueryClient(); // 서버: 요청마다 새로 생성 (데이터 격리)
+  } else {
+    // 브라우저: 한 번만 생성해서 재사용
+    if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    return browserQueryClient;
+  }
+}
+
+export default function QueryProvider({ children }: { children: React.ReactNode }) {
+  // useState 대신 getQueryClient() 직접 호출
+  const queryClient = getQueryClient();
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }

--- a/src/shared/hooks/useAuth.tsx
+++ b/src/shared/hooks/useAuth.tsx
@@ -1,46 +1,20 @@
 'use client';
 import { useQuery } from '@tanstack/react-query';
-import { usePathname, useSearchParams } from 'next/navigation';
 
 import { authKeys } from '../config/queryKeys';
 import type { IUserResponseData } from '../types';
 import { fetcher } from '../utils/fetcher.client';
 
-interface IAuthState {
-  isSignedIn: boolean;
-  pending: boolean;
-  userData: IUserResponseData['userData'] | null;
-  isLinked: boolean;
-}
-async function fetchAuth(): Promise<IAuthState> {
-  const res = await fetcher<IUserResponseData>('/api/user', {
+async function fetchAuth(): Promise<IUserResponseData> {
+  return await fetcher<IUserResponseData>('/api/user', {
     credentials: 'include',
   });
-
-  return {
-    isSignedIn: res.response === 'ok',
-    pending: false,
-    userData: res.userData || null,
-    isLinked: res.isLinked || false,
-  };
 }
 
 export function useAuth() {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-
-  const query = useQuery({
-    queryKey: authKeys.searchParams(pathname, searchParams.toString()),
+  return useQuery({
+    queryKey: authKeys.all,
     queryFn: fetchAuth,
-    staleTime: 5 * 60 * 1000, // 5 minutes
     retry: false,
   });
-
-  if (query.isLoading) {
-    return { isSignedIn: false, pending: true, userData: null, isLinked: false };
-  }
-  if (query.isError || query.data == null) {
-    return { isSignedIn: false, pending: false, userData: null, isLinked: false };
-  }
-  return query.data;
 }

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -266,5 +266,6 @@ export interface INotificationResponseData {
   response: 'ng' | 'ok' | 'unAuthorized';
   message: string;
   data: INotificationDetailData[] | [];
+  noReadCount: number;
   nextCursor: string | null;
 }

--- a/src/widgets/header/ui/_MobileHeader.tsx
+++ b/src/widgets/header/ui/_MobileHeader.tsx
@@ -23,9 +23,6 @@ import { UlButton } from './_UlButton';
 
 interface IMobileHeader {
   userId: string | undefined;
-  notificationNoReadCount: number | undefined;
-  isSignedIn: boolean;
-  isPending: boolean;
   handleClickNextNotifications: () => void;
   hasNextPage: boolean;
   isFetching: boolean;
@@ -34,9 +31,6 @@ interface IMobileHeader {
 
 export const MobileHeader = ({
   userId,
-  notificationNoReadCount,
-  isSignedIn,
-  isPending,
   handleClickNextNotifications: onClickNextNotifications,
   hasNextPage,
   isFetching,
@@ -44,6 +38,7 @@ export const MobileHeader = ({
 }: IMobileHeader) => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [notificationMenuOpen, setNotificationMenuOpen] = useState(false);
+  const notificationNoReadCount = notificationData?.pages[0]?.noReadCount ?? 0;
   useEffect(() => {
     if (typeof window === 'undefined') return;
     // 브라우저 크기 추적
@@ -93,10 +88,10 @@ export const MobileHeader = ({
                   <div className="flex flex-col gap-4 lg:hidden">
                     <Link
                       className="font-semibold leading-6 text-gray-900"
-                      href={isSignedIn ? URLS.MYPAGE : URLS.LOGIN}
+                      href={userId != null ? URLS.MYPAGE : URLS.LOGIN}
                       onClick={handleChangeMobileMenuOpen}
                     >
-                      <UlButton enText="" text={isPending ? '로딩중..' : isSignedIn ? '마이페이지' : '로그인'} />
+                      <UlButton enText="" text={userId != null ? '마이페이지' : '로그인'} />
                     </Link>
                     <UlButton enText="GoldHand" text="고운황금손">
                       <div className="flex w-full flex-col items-center justify-center gap-6 py-6 text-base font-semibold leading-6 text-gray-900">
@@ -169,15 +164,11 @@ export const MobileHeader = ({
       <Drawer direction="bottom" open={notificationMenuOpen} onOpenChange={open => setNotificationMenuOpen(open)}>
         {userId != null && (
           <DrawerTrigger
-            aria-label={
-              notificationNoReadCount != null && notificationNoReadCount > 0
-                ? `알림 ${notificationNoReadCount}개`
-                : '알림'
-            }
+            aria-label={notificationNoReadCount > 0 ? `알림 ${notificationNoReadCount}개` : '알림'}
             className={cn('absolute right-6 top-1/2 -translate-y-1/2 px-6', 'lg:hidden')}
           >
             <Bell aria-hidden="true" size={20} />
-            {notificationNoReadCount != null && notificationNoReadCount > 0 && (
+            {notificationNoReadCount > 0 && (
               <div
                 aria-hidden="true"
                 className="absolute -right-2 -top-2 inline-flex h-4 w-4 animate-pulse items-center justify-center rounded-full bg-red-600 p-1 text-xs font-semibold text-white duration-500"

--- a/src/widgets/header/ui/_WebHeader.tsx
+++ b/src/widgets/header/ui/_WebHeader.tsx
@@ -21,10 +21,7 @@ import { URLS } from '@/src/widgets/header';
 import { UlButton } from './_UlButton';
 
 interface IWebHeaderProps {
-  isSignedIn: boolean;
-  isPending: boolean;
   userId: string | undefined;
-  notificationNoReadCount: number | undefined;
   handleClickNextNotifications: () => void;
   hasNextPage: boolean;
   isFetching: boolean;
@@ -32,16 +29,15 @@ interface IWebHeaderProps {
 }
 
 export const WebHeader = ({
-  isSignedIn,
-  isPending,
   userId,
-  notificationNoReadCount,
   handleClickNextNotifications: onClickNextNotifications,
   hasNextPage,
   isFetching,
   notificationData,
 }: IWebHeaderProps) => {
   const [notificationMenuOpen, setNotificationMenuOpen] = useState(false);
+  const notificationNoReadCount = notificationData?.pages[0]?.noReadCount ?? 0;
+
   return (
     <Popover open={notificationMenuOpen} onOpenChange={open => setNotificationMenuOpen(open)}>
       <NavigationMenu>
@@ -136,24 +132,18 @@ export const WebHeader = ({
           </NavigationMenuItem>
           <NavigationMenuItem>
             <NavigationMenuLink asChild className="w-40 rounded-full border border-[#0F2E16]">
-              <Link href={isSignedIn ? URLS.MYPAGE : URLS.LOGIN}>
-                {isPending ? '로딩중..' : isSignedIn ? '마이페이지' : '로그인'}
-              </Link>
+              <Link href={userId != null ? URLS.MYPAGE : URLS.LOGIN}>{userId != null ? '마이페이지' : '로그인'}</Link>
             </NavigationMenuLink>
           </NavigationMenuItem>
           {userId != null && (
             <NavigationMenuItem>
               <PopoverTrigger asChild>
                 <button
-                  aria-label={
-                    notificationNoReadCount != null && notificationNoReadCount > 0
-                      ? `알림 ${notificationNoReadCount}개`
-                      : '알림'
-                  }
+                  aria-label={notificationNoReadCount > 0 ? `알림 ${notificationNoReadCount}개` : '알림'}
                   className="relative flex items-center justify-center"
                 >
                   <Bell aria-hidden="true" size={20} />
-                  {notificationNoReadCount != null && notificationNoReadCount > 0 && (
+                  {notificationNoReadCount > 0 && (
                     <div
                       aria-hidden="true"
                       className="absolute -right-2 -top-2 inline-flex h-4 w-4 animate-pulse items-center justify-center rounded-full bg-red-600 p-1 text-xs font-semibold text-white duration-500"

--- a/src/widgets/header/ui/header.tsx
+++ b/src/widgets/header/ui/header.tsx
@@ -3,25 +3,20 @@
 import Link from 'next/link';
 
 import { useAlarm } from '@/src/shared/hooks/useAlarm';
-import { useAuth } from '@/src/shared/hooks/useAuth';
 import { useInfiniteAlarmQuery } from '@/src/shared/hooks/useInfiniteAlarmQuery';
+import type { IUserDetailData } from '@/src/shared/types';
 
 import { MobileHeader } from './_MobileHeader';
 import { WebHeader } from './_WebHeader';
 
-export const Header = () => {
-  const { isSignedIn, pending: isPending, userData } = useAuth();
-  const {
-    data: notificationData,
-    isFetching,
-    hasNextPage,
-    fetchNextPage,
-  } = useInfiniteAlarmQuery(userData?.userId ?? '');
-  useAlarm(userData?.userId ?? '');
+interface IHeaderProps {
+  userData: IUserDetailData | null;
+}
 
-  const notificationNoReadCount = notificationData?.pages.reduce((acc, page) => {
-    return acc + page.data.filter(item => !item.isRead).length;
-  }, 0);
+export const Header = ({ userData }: IHeaderProps) => {
+  const userId = userData?.userId;
+  const { data: notificationData, isFetching, hasNextPage, fetchNextPage } = useInfiniteAlarmQuery(userId ?? '');
+  useAlarm(userId ?? '');
 
   const onClickNextNotifications = () => {
     if (hasNextPage && !isFetching) {
@@ -42,22 +37,15 @@ export const Header = () => {
           handleClickNextNotifications={onClickNextNotifications}
           hasNextPage={hasNextPage}
           isFetching={isFetching}
-          isPending={isPending}
-          isSignedIn={isSignedIn}
           notificationData={notificationData}
-          notificationNoReadCount={notificationNoReadCount}
-          userId={userData?.userId}
+          userId={userId}
         />
-
         <MobileHeader
           handleClickNextNotifications={onClickNextNotifications}
           hasNextPage={hasNextPage}
           isFetching={isFetching}
-          isPending={isPending}
-          isSignedIn={isSignedIn}
           notificationData={notificationData}
-          notificationNoReadCount={notificationNoReadCount}
-          userId={userData?.userId}
+          userId={userId}
         />
       </header>
     </>


### PR DESCRIPTION
# AS-IS
- Header 컴포넌트 내부에서 userData를 fetching하고, pathname과 searchParams을 queryKey로 지정하여 라우트마다 캐싱을 하고 있음.
- RSC에 대한 이해도가 부족한 상태에서 tanstack query를 사용해 hydration error가 간헐적으로 발생하고 있었고, userData또한 불필요한 쿼리키 정책으로 네트워크 요청을 페이지 이동시마다 보내고 있었음

# TO-BE
- Root Layout에서 userData를 fetch한 후 Header에 props로 내려줌.
### 기대효과
- userData는 페이지 진입과 로그인할 때만 요청한 후, 이후 웹사이트 사용 시에는 네트워크 요청 없음.
- 서버 컴포넌트에서 fetch하기에 네트워크 지연 감소로 성능 향상 및 쿠키 코드가 JS번들에 포함되지 않음.
- accessToken을 매 요청시마다 http header에 포함하고, 서버에서 이 쿠키를 검증해서 만료될 시 401 error를 보내주는 것이 맞는 패턴 
