### PR TITLE
사용자가 로그인될때만 사용할 수 있는 getUserLoginData 및 authFetcher 검증 로직 강화

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,6 @@ import './globals.css';
 import type { Metadata } from 'next';
 import dynamic from 'next/dynamic';
 import localFont from 'next/font/local';
-import { cookies } from 'next/headers';
 import Script from 'next/script';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
 import { Suspense } from 'react';
@@ -11,8 +10,7 @@ import { ToastContainer } from 'react-toastify';
 
 import QueryProvider from '@/src/app/providers/query-provider';
 import { ThemeProvider } from '@/src/app/providers/theme-provider';
-import type { IUserResponseData } from '@/src/shared/types';
-import { fetcher } from '@/src/shared/utils/fetcher.client';
+import { getUserData } from '@/src/shared/api/getUserData';
 import { EventModal } from '@/src/widgets/event/ui/EventModal';
 import { Header } from '@/src/widgets/header';
 
@@ -41,13 +39,7 @@ export default async function Layout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const cookieStore = cookies();
-  const userData = await fetcher<IUserResponseData>('/api/user', {
-    cache: 'no-cache',
-    headers: {
-      Cookie: cookieStore.toString(),
-    },
-  });
+  const userData = await getUserData();
 
   return (
     <html className={`${pretendard.variable} font-pretendard`} lang="ko" suppressHydrationWarning>

--- a/app/manager/[docId]/page.tsx
+++ b/app/manager/[docId]/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react';
 
-import { getUserData } from '@/src/shared/api/getUserData';
+import { getUserLoginData } from '@/src/shared/api/getUserData';
 import LoadingBar from '@/src/shared/ui/loadingBar';
 
 import { getManagerApplyDetailData } from './api';
@@ -12,7 +12,7 @@ type TPageProps = {
 
 export default async function Page({ params }: TPageProps) {
   const { docId } = await params;
-  const userData = await getUserData();
+  const userData = await getUserLoginData();
   const data = await getManagerApplyDetailData({
     docId,
   });

--- a/app/manager/apply/page.tsx
+++ b/app/manager/apply/page.tsx
@@ -1,10 +1,10 @@
-import { getUserData } from '@/src/shared/api/getUserData';
+import { getUserLoginData } from '@/src/shared/api/getUserData';
 import MyGoogleCaptcha from '@/src/shared/ui/GoogleRecaptcha';
 
 import { ManagerApplyPage } from './ui/ManagerApplyPage';
 
 export default async function Page() {
-  const userData = await getUserData();
+  const userData = await getUserLoginData();
   return (
     <MyGoogleCaptcha>
       <ManagerApplyPage userData={userData.userData} />

--- a/app/manager/list/page.tsx
+++ b/app/manager/list/page.tsx
@@ -1,6 +1,6 @@
 import type { SearchParams } from 'nuqs/server';
 
-import { getUserData } from '@/src/shared/api/getUserData';
+import { getUserLoginData } from '@/src/shared/api/getUserData';
 import { loadManagerListParams } from '@/src/shared/lib/nuqs/searchParams';
 
 import { getManagerListData } from './api';
@@ -11,7 +11,7 @@ type TPageProps = {
 };
 
 export default async function Page({ searchParams }: TPageProps) {
-  const userData = await getUserData();
+  const userData = await getUserLoginData();
   const { page } = await loadManagerListParams(searchParams);
   const data = await getManagerListData(page);
 

--- a/app/mypage/edit/page.tsx
+++ b/app/mypage/edit/page.tsx
@@ -1,9 +1,9 @@
-import { getUserData } from '@/src/shared/api/getUserData';
+import { getUserLoginData } from '@/src/shared/api/getUserData';
 
 import { MyPageEditPage } from './ui/MyPageEditPage';
 
 export default async function Page() {
-  const userData = await getUserData();
+  const userData = await getUserLoginData();
 
   if (userData.response === 'ng') {
     throw new Error(userData.message);

--- a/src/shared/api/getUserData.ts
+++ b/src/shared/api/getUserData.ts
@@ -1,12 +1,27 @@
+import { cookies } from 'next/headers';
+
 import type { IUserResponseData } from '@/src/shared/types';
 
+import { fetcher } from '../utils/fetcher.client';
 import { authFetcher } from '../utils/fetcher.server';
 
 /*
 서버 컴포넌트나 서버 액션에서 user 데이터를 가져올 때 사용
 */
 export async function getUserData(): Promise<IUserResponseData> {
-  const result = await authFetcher<IUserResponseData>('/api/user', {
+  const cookieStore = cookies();
+  const userData = await fetcher<IUserResponseData>('/api/user', {
+    cache: 'no-cache',
+    headers: {
+      Cookie: cookieStore.toString(),
+    },
+  });
+  return userData;
+}
+
+// 로그인이 되어있을 때 로그인한 유저의 데이터를 가져올 때 사용
+export async function getUserLoginData(): Promise<IUserResponseData> {
+  const result = await authFetcher<IUserResponseData>('/api/user/login', {
     cache: 'no-store',
   });
 

--- a/src/shared/utils/fetcher.server.ts
+++ b/src/shared/utils/fetcher.server.ts
@@ -11,6 +11,10 @@ export async function authFetcher<T>(path: string, options: RequestInit = {}): P
   const cookiesObj = parse(rawCookie);
   const accessToken = cookiesObj['accessToken'];
 
+  if (!accessToken) {
+    throw new Error('인증 토큰이 없습니다. 로그인 후 이용해주세요.');
+  }
+
   const response = await fetch(`${apiUrl}${path}`, {
     ...options,
     method: options.method || 'GET',


### PR DESCRIPTION
### authFetcher는 사용자가 로그인할 때만 사용할 수 있는 api endpoint에 접근할 때 사용하기 떄문에, Cookie의 accessToken이 없으면 바로 error를 throw