### PR TITLE
전화번호 인증 되지 않은 유저는 카카오톡 알림설정 못하게하고 전화번호 인증 유도하는 fallback UI 추가 및…

### DIFF
--- a/app/api/auth/kakao/callback/route.ts
+++ b/app/api/auth/kakao/callback/route.ts
@@ -30,6 +30,14 @@ async function saveUserProfile(uid: string, email: string) {
     deletedAt: null,
     kakaoId: uid,
     kakaoEmail: email,
+    kakaoAlarmSettings: {
+      alarmComment: false,
+      alarmNews: false,
+      alarmNewPost: false,
+      alarmEditPost: false,
+      alarmNewComment: false,
+      alarmEditComment: false,
+    },
   };
   await setDoc(doc(db, 'users', uid), defaultUserData);
 }

--- a/app/api/auth/naver/callback/route.ts
+++ b/app/api/auth/naver/callback/route.ts
@@ -30,7 +30,16 @@ async function saveUserProfile(uid: string, email: string) {
     deletedAt: null,
     kakaoId: null,
     kakaoEmail: null,
+    kakaoAlarmSettings: {
+      alarmComment: false,
+      alarmNews: false,
+      alarmNewPost: false,
+      alarmEditPost: false,
+      alarmNewComment: false,
+      alarmEditComment: false,
+    },
   };
+
   await setDoc(doc(db, 'users', uid), defaultUserData);
 }
 

--- a/src/__mock__/user/index.ts
+++ b/src/__mock__/user/index.ts
@@ -28,6 +28,14 @@ export const mockUserData: {
     provider: 'kakao',
     kakaoId: 'kakao-test-id',
     kakaoEmail: 'kakao-test@example.com',
+    kakaoAlarmSettings: {
+      alarmComment: true,
+      alarmNews: false,
+      alarmNewPost: true,
+      alarmEditPost: false,
+      alarmNewComment: true,
+      alarmEditComment: false,
+    },
   },
   isLinked: true,
 };

--- a/src/feature/mypage/ui/MyPageKaKaoAlarmSetting.tsx
+++ b/src/feature/mypage/ui/MyPageKaKaoAlarmSetting.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import Image from 'next/image';
+import Link from 'next/link';
+
 import { cn } from '@/lib/utils';
 import { DEFAULT_ALARM_SETTINGS, useUpdateKakaoAlarmSettingMutation } from '@/src/entities/mypage';
 import type { IKakaoAlarmSettings, IMyPageResponseData } from '@/src/shared/types';
@@ -40,6 +43,34 @@ const NotifyRow = ({ title, help, checked, onCheckedChange: handleCheckedChange 
   </div>
 );
 
+const KakaoAlarmLinkFallback = () => (
+  <section aria-label="카카오톡 알림 설정" className={cn('mt-6 px-4', 'md:px-0')}>
+    <div className="mb-5">
+      <h2 className="text-[20px] font-bold tracking-[-0.02em] text-stone-900">카카오톡 알림 설정</h2>
+      <p className="mt-1 text-[13.5px] text-stone-500">받고 싶은 알림만 켜고 끄세요. 변경 사항은 즉시 저장됩니다.</p>
+    </div>
+    <div className="flex flex-col items-center gap-4 border border-stone-200 bg-white px-5 py-10 text-center">
+      <Image alt="카카오톡" height={40} src="/icon/kakaotalk.png" width={40} />
+      <div className="flex flex-col gap-1">
+        <span className="text-[15px] font-semibold text-stone-900">전화번호 인증이 필요합니다</span>
+        <span className="text-[13px] text-stone-500">
+          카카오톡 알림은 전화번호 인증을 완료한 회원에게만 제공됩니다.
+        </span>
+      </div>
+      <Link
+        className={cn(
+          'mt-2 inline-flex items-center justify-center px-6 py-2.5',
+          'bg-kakao text-[13.5px] font-semibold text-stone-900',
+          'transition-opacity hover:opacity-80',
+        )}
+        href="/signup/phone"
+      >
+        지금 인증하기
+      </Link>
+    </div>
+  </section>
+);
+
 export const MyPageKaKaoAlarmSetting = ({ myPageData }: IMyPageKaKaoAlarmSettingProps) => {
   const isAdmin = myPageData.data.userData?.grade === 'admin';
   const alarms: IKakaoAlarmSettings = {
@@ -64,6 +95,10 @@ export const MyPageKaKaoAlarmSetting = ({ myPageData }: IMyPageKaKaoAlarmSetting
   const handleToggle = (key: keyof IKakaoAlarmSettings) => (value: boolean) => {
     mutate({ key, value });
   };
+
+  if (!myPageData.data.isLinked) {
+    return <KakaoAlarmLinkFallback />;
+  }
 
   return (
     <section aria-label="카카오톡 알림 설정" className={cn('mt-6 px-4', 'md:px-0')}>

--- a/src/shared/hooks/useInfiniteAlarmQuery.ts
+++ b/src/shared/hooks/useInfiniteAlarmQuery.ts
@@ -15,5 +15,6 @@ export const useInfiniteAlarmQuery = (userId: string) => {
     initialPageParam: 1,
     getNextPageParam: lastPage => lastPage.nextCursor,
     enabled: !!userId,
+    refetchInterval: 1000 * 30, // 30초마다 새로고침
   });
 };

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -114,7 +114,7 @@ export interface IUserDetailData {
   kakaoId: string | null;
   kakaoEmail: string | null;
   fcmTokens?: string[] | null;
-  kakaoAlarmSettings?: IKakaoAlarmSettings;
+  kakaoAlarmSettings: IKakaoAlarmSettings;
 }
 
 export interface IUserResponseData {


### PR DESCRIPTION
### 전화번호 인증하지 않은 유저는 카카오톡 알림 설정 불가
- 번호가 있어야 카카오톡 알림 발송이 가능함.
- 알림설정 컴포넌트 띄우지 않고 전화번호 인증 링크로 넘어가는 fallback UI 추가

### kakaoSettings 속성 users collection 스키마에 필수 타입으로 설정
- default : 모든 값 false

### 알람 infiniteQuery refetchInterval time 30초로 설정
- 이 서비스에 알림이 굳이 SSE까지 연동해가면서 실시간으로 수신할 만큼 긴급성이 있진 않음
- SSE 제거하고 30초 polling으로 변경