### PR TITLE
보안 취약점 수정 및 race condition 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ rule.mjs
 # docs
 /docs
 비즈톡*
+
+.vscode

--- a/app/api/reservation/detail/route.ts
+++ b/app/api/reservation/detail/route.ts
@@ -68,33 +68,50 @@ export async function GET(request: NextRequest) {
     const data = docSnap.data() as IReservationDetailData;
 
     if (data.secret) {
-      // 비밀글&비회원
-      if (data.userId == null) {
-        const decoded = jwt.verify(reservationToken?.value || '', process.env.JWT_SECRET!) as { docId: string } | null;
-        if (reservationToken == null || decoded == null || decoded.docId !== docId) {
-          return typedJson<IResponseBody>(
-            {
-              response: 'ng',
-              message: '비밀글 인증에 실패하였습니다.',
-              data: defaultData,
-            },
-            { status: 403 },
-          );
+      let isAdmin = false;
+      let verifiedUid: string | null = null;
+
+      if (accessToken?.value) {
+        try {
+          const decodedToken = await getAdminAuth(firebaseAdminApp).verifyIdToken(accessToken.value);
+          verifiedUid = decodedToken.uid;
+          const userDocRef = doc(db, 'users', verifiedUid);
+          const userDocSnap = await getDoc(userDocRef);
+          isAdmin = userDocSnap.exists() && userDocSnap.data().grade === 'admin';
+        } catch {
+          // 토큰 검증 실패 시 isAdmin, verifiedUid 기본값 유지
         }
       }
-      // 비밀글&회원
-      else {
-        const decodedToken = await getAdminAuth(firebaseAdminApp).verifyIdToken(accessToken?.value || '');
-        const uid = decodedToken.uid;
-        if (uid !== data.userId) {
-          return typedJson<IResponseBody>(
-            {
-              response: 'ng',
-              message: '해당 사용자가 작성한 글이 아닙니다.',
-              data: defaultData,
-            },
-            { status: 403 },
-          );
+
+      if (!isAdmin) {
+        // 비밀글&비회원
+        if (data.userId == null) {
+          const decoded = jwt.verify(reservationToken?.value || '', process.env.JWT_SECRET!) as {
+            docId: string;
+          } | null;
+          if (reservationToken == null || decoded == null || decoded.docId !== docId) {
+            return typedJson<IResponseBody>(
+              {
+                response: 'ng',
+                message: '비밀글 인증에 실패하였습니다.',
+                data: defaultData,
+              },
+              { status: 403 },
+            );
+          }
+        }
+        // 비밀글&회원
+        else {
+          if (verifiedUid == null || verifiedUid !== data.userId) {
+            return typedJson<IResponseBody>(
+              {
+                response: 'ng',
+                message: '해당 사용자가 작성한 글이 아닙니다.',
+                data: defaultData,
+              },
+              { status: 403 },
+            );
+          }
         }
       }
     }

--- a/app/api/reservation/route.ts
+++ b/app/api/reservation/route.ts
@@ -13,6 +13,7 @@ import {
 import type { NextRequest } from 'next/server';
 
 import { firebaseApp } from '@/src/shared/config/firebase';
+import { checkAdminAuth } from '@/src/shared/lib/checkAdminAuth';
 import type { IReservationDetailData } from '@/src/shared/types';
 import { typedJson } from '@/src/shared/utils';
 
@@ -28,6 +29,10 @@ export async function GET(request: NextRequest) {
   const hideSecret = searchParams.get('hideSecret');
   const PAGE_SIZE = 10;
   const preloadCount = 1;
+
+  const authResult = await checkAdminAuth();
+  const isAdmin = authResult.ok && authResult.isAdmin;
+  const currentUserId = authResult.ok ? authResult.uid : null;
 
   const totalToFetch = PAGE_SIZE * preloadCount;
   const startAtIndex = (page - 1) * PAGE_SIZE;
@@ -60,10 +65,25 @@ export async function GET(request: NextRequest) {
     }
 
     const snapShot = await getDocs(paginatedQuery);
-    const consults = snapShot.docs.map(doc => ({
-      id: doc.id,
-      ...doc.data(),
-    }));
+    const consults = snapShot.docs.map(doc => {
+      const data = { id: doc.id, ...doc.data() };
+
+      // 비밀글이면서 admin도 아니고 작성자 본인도 아닌 경우 민감 필드 마스킹
+      if (data.secret && !isAdmin && (currentUserId === null || currentUserId !== data.userId)) {
+        return {
+          ...data,
+          title: '비밀글입니다.',
+          content: '',
+          name: '',
+          phoneNumber: '',
+          bornDate: null,
+          location: '',
+          password: null,
+        };
+      }
+
+      return data;
+    });
 
     return typedJson<IResponseBody>({ message: 'ok', consultData: consults, totalDataLength }, { status: 200 });
   } catch (error: any) {

--- a/app/reservation/list/ui/ReservationCard.tsx
+++ b/app/reservation/list/ui/ReservationCard.tsx
@@ -70,17 +70,21 @@ export const ReservationCard = ({
   const [isPasswordDialogOpen, setIsPasswordDialogOpen] = useState(false);
   const [isAlertDialogOpen, setIsAlertDialogOpen] = useState(false);
   const { data: userData } = useAuth();
+  const isAdmin = userData?.userData?.grade === 'admin';
 
   const handleOnClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.stopPropagation();
-    if (isSecret && author === '비회원') {
-      setIsPasswordDialogOpen(true);
-      return;
-    }
 
-    if (isSecret && author !== '비회원' && dataUserId !== userData?.userData?.userId) {
-      setIsAlertDialogOpen(true);
-      return;
+    if (!isAdmin) {
+      if (isSecret && author === '비회원') {
+        setIsPasswordDialogOpen(true);
+        return;
+      }
+
+      if (isSecret && author !== '비회원' && dataUserId !== userData?.userData?.userId) {
+        setIsAlertDialogOpen(true);
+        return;
+      }
     }
 
     // 조회수 기록

--- a/src/feature/mypage/ui/MyPageInfoCard.tsx
+++ b/src/feature/mypage/ui/MyPageInfoCard.tsx
@@ -6,7 +6,7 @@ import { useTransition } from 'react';
 
 import { cn } from '@/lib/utils';
 import { firebaseApp } from '@/src/shared/config/firebase';
-import { authKeys } from '@/src/shared/config/queryKeys';
+import { authKeys, userKeys } from '@/src/shared/config/queryKeys';
 import type { IMyPageResponseData } from '@/src/shared/types';
 import { LoadingSpinnerOverlay } from '@/src/shared/ui/LoadingSpinnerOverlay';
 import { formatPhoneNumber, toastError, toastSuccess } from '@/src/shared/utils';
@@ -25,7 +25,8 @@ export const MyPageInfoCard = ({ myPageData, handleWithdrawModalOpen }: IMyPageI
   const { mutate: logout } = useLogoutMutation({
     onSuccess: data => {
       signOut(auth).then(() => {
-        queryClient.invalidateQueries({ queryKey: authKeys.all });
+        queryClient.removeQueries({ queryKey: authKeys.all });
+        queryClient.removeQueries({ queryKey: userKeys.all });
         toastSuccess(data.message || '로그아웃 되었습니다.');
         setTimeout(() => {
           router.replace('/');


### PR DESCRIPTION
### reservation list를 받아오는 api에서, curl로 직접 요청을 날리면 secret : true여도 해당 상담의 원본 데이터가 그대로 반환됨.
- 클라이언트에서 secret 속성을 받아 데이터를 placeholder로 치환하는 구조라 해당 문제 발생
- 서버단에서 운영자이거나, 로그인했지만 자기 자신 게시글이 아닌 모든 비밀글에 대해 서버단에서 마스킹 처리 후 데이터 return

### 운영자일 경우 예약상담 비밀글/회원 여부 상관없이 모두 조회 가능 로직 추가
- 조건문마다 isAdmin 분기 추가

### 로그아웃시 쿼리를 removeQueries를 사용해 제거해서 race condition 제거
- 로그아웃 - 로그인 반복할 때 reservation Form 작성 시 비밀번호 작성 input은 노출되나, 스키마는 로그인 된 상태로 초기 마운트 된 후 바뀌지 않는 race condition 발생
- 로그아웃 할 때 쿼리 자체를 제거해서 userData를 조작할 때 반드시 fresh한 데이터를 RSC에서 받아오도록 로직 수정