### PR TITLE
예약상담 신청안내에 홈페이지 상담신청 유도 링크 추가 및 보안 개선

### DIFF
--- a/app/api/reservation/detail/password/route.ts
+++ b/app/api/reservation/detail/password/route.ts
@@ -71,33 +71,44 @@ export async function POST(request: NextRequest) {
 
     const data = docSnap.data() as IReservationDetailData;
 
+    // 회원이 작성한 글은 password 기반 인증 대상이 아니므로(소유권은 userId로만 판별) 무조건 거부
+    if (data.userId != null) {
+      return typedJson<IResponseBody>(
+        {
+          response: 'ng',
+          message: '회원이 작성한 게시글은 비밀번호로 접근할 수 없습니다.',
+          data: defaultData,
+          reservationToken: null,
+        },
+        { status: 403 },
+      );
+    }
+
     // 비회원 - 비밀번호 검증
-    if (data.userId == null) {
-      if (password === null) {
-        return typedJson<IResponseBody>(
-          {
-            response: 'ng',
-            message: 'password is required',
-            data: defaultData,
-            reservationToken: null,
-          },
-          { status: 400 },
-        );
-      }
+    if (password === null) {
+      return typedJson<IResponseBody>(
+        {
+          response: 'ng',
+          message: 'password is required',
+          data: defaultData,
+          reservationToken: null,
+        },
+        { status: 400 },
+      );
+    }
 
-      const isMatch = await bcrypt.compare(password, data.password || '');
+    const isMatch = await bcrypt.compare(password, data.password || '');
 
-      if (!isMatch) {
-        return typedJson<IResponseBody>(
-          {
-            response: 'ng',
-            message: '비밀번호가 틀립니다.',
-            data: defaultData,
-            reservationToken: null,
-          },
-          { status: 403 },
-        );
-      }
+    if (!isMatch) {
+      return typedJson<IResponseBody>(
+        {
+          response: 'ng',
+          message: '비밀번호가 틀립니다.',
+          data: defaultData,
+          reservationToken: null,
+        },
+        { status: 403 },
+      );
     }
 
     // 인증 토큰을 쿠키에 저장 - 클라이언트 서버 액션에서 저장할 예정

--- a/app/api/reservation/detail/route.ts
+++ b/app/api/reservation/detail/route.ts
@@ -50,6 +50,7 @@ export async function GET(request: NextRequest) {
       { status: 400 },
     );
   }
+
   try {
     const app = firebaseApp;
     const db = getFirestore(app);
@@ -69,29 +70,36 @@ export async function GET(request: NextRequest) {
 
     const data = docSnap.data() as IReservationDetailData;
 
-    if (data.secret) {
-      let isAdmin = false;
-      let verifiedUid: string | null = null;
+    let isAdmin = false;
+    let verifiedUid: string | null = null;
 
-      if (accessToken?.value) {
-        try {
-          const decodedToken = await getAdminAuth(firebaseAdminApp).verifyIdToken(accessToken.value);
-          verifiedUid = decodedToken.uid;
-          const userDocRef = doc(db, 'users', verifiedUid);
-          const userDocSnap = await getDoc(userDocRef);
-          isAdmin = userDocSnap.exists() && userDocSnap.data().grade === 'admin';
-        } catch {
-          // 토큰 검증 실패 시 isAdmin, verifiedUid 기본값 유지
-        }
+    if (accessToken?.value) {
+      try {
+        const decodedToken = await getAdminAuth(firebaseAdminApp).verifyIdToken(accessToken.value);
+        verifiedUid = decodedToken.uid;
+        const userDocRef = doc(db, 'users', verifiedUid);
+        const userDocSnap = await getDoc(userDocRef);
+        isAdmin = userDocSnap.exists() && userDocSnap.data().grade === 'admin';
+      } catch {
+        // 토큰 검증 실패 시 isAdmin, verifiedUid 기본값 유지
       }
+    }
 
+    let reservationTokenDocId: string | null = null;
+    if (reservationToken?.value) {
+      try {
+        const decoded = jwt.verify(reservationToken.value, process.env.JWT_SECRET!) as { docId: string } | null;
+        reservationTokenDocId = decoded?.docId ?? null;
+      } catch {
+        // 토큰 검증 실패 시 reservationTokenDocId 기본값(null) 유지
+      }
+    }
+
+    if (data.secret) {
       if (!isAdmin) {
         // 비밀글&비회원
         if (data.userId == null) {
-          const decoded = jwt.verify(reservationToken?.value || '', process.env.JWT_SECRET!) as {
-            docId: string;
-          } | null;
-          if (reservationToken == null || decoded == null || decoded.docId !== docId) {
+          if (reservationTokenDocId !== docId) {
             return typedJson<IResponseBody>(
               {
                 response: 'ng',
@@ -118,6 +126,10 @@ export async function GET(request: NextRequest) {
       }
     }
 
+    // 연락처(phoneNumber)는 작성자 본인 또는 관리자만 조회 가능
+    const isOwner = data.userId != null ? verifiedUid === data.userId : reservationTokenDocId === docId;
+    const canViewPhoneNumber = isAdmin || isOwner;
+
     const commentsRef = collection(db, 'consults', docId, 'comments');
     const q = query(commentsRef, orderBy('createdAt', 'desc'));
 
@@ -133,6 +145,7 @@ export async function GET(request: NextRequest) {
       message: 'ok',
       data: {
         ...data,
+        phoneNumber: canViewPhoneNumber ? data.phoneNumber : '',
         comments,
       },
     };

--- a/app/api/reservation/route.ts
+++ b/app/api/reservation/route.ts
@@ -33,7 +33,9 @@ export async function GET(request: NextRequest) {
     );
 
     const maskSecretFields = (data: IReservationDetailData & { id: string }) => {
-      if (data.secret && !isAdmin && (currentUserId === null || currentUserId !== data.userId)) {
+      const isOwner = currentUserId !== null && currentUserId === data.userId;
+
+      if (data.secret && !isAdmin && !isOwner) {
         return {
           ...data,
           title: data.title,
@@ -45,7 +47,9 @@ export async function GET(request: NextRequest) {
           password: null,
         };
       }
-      return data;
+
+      // 리스트 UI에서는 연락처를 전혀 사용하지 않으므로 권한과 무관하게 항상 마스킹
+      return { ...data, phoneNumber: '' };
     };
 
     const consults = [...pinnedItems, ...pageItems].map(maskSecretFields);

--- a/app/reservation/page.tsx
+++ b/app/reservation/page.tsx
@@ -39,11 +39,25 @@ export default function ReservationPage() {
 
                 {/* Step 1 연락 chip */}
                 {index === 0 && (
-                  <div className="mt-3.5 flex flex-wrap gap-2">
+                  <div className={cn('mt-3.5 flex flex-col gap-2', 'md:flex-row md:flex-wrap')}>
+                    <Link
+                      className={cn(
+                        'flex w-full items-center justify-center gap-2 rounded-full bg-[#728146] px-3.5 py-2 text-sm font-semibold text-white transition-colors',
+                        'hover:bg-[#062E16]',
+                        'md:inline-flex md:w-auto md:justify-start',
+                      )}
+                      href="/reservation/apply"
+                    >
+                      <svg fill="none" height={14} stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24" width={14}>
+                        <path d="M5 12h14M13 6l6 6-6 6" />
+                      </svg>
+                      <span>예약상담 신청하기</span>
+                    </Link>
                     <a
                       className={cn(
-                        'inline-flex items-center gap-2 rounded-full border border-[#E8E1D2] bg-white px-3.5 py-2 text-sm text-[#1B1814] transition-all',
+                        'flex w-full items-center justify-center gap-2 rounded-full border border-[#E8E1D2] bg-white px-3.5 py-2 text-sm text-[#1B1814] transition-all',
                         'hover:border-[#A88547] hover:bg-[#F6F1E7]',
+                        'md:inline-flex md:w-auto md:justify-start',
                       )}
                       href="tel:01044370431"
                     >
@@ -58,7 +72,10 @@ export default function ReservationPage() {
                       <span className="font-serif tracking-wide">010-4437-0431</span>
                     </a>
                     <a
-                      className="inline-flex items-center gap-2 rounded-full bg-[#FAE100] px-3.5 py-2 text-sm font-semibold text-[#3C1E1E] transition-all hover:bg-[#f0d600]"
+                      className={cn(
+                        'flex w-full items-center justify-center gap-2 rounded-full bg-[#FAE100] px-3.5 py-2 text-sm font-semibold text-[#3C1E1E] transition-all hover:bg-[#f0d600]',
+                        'md:inline-flex md:w-auto md:justify-start',
+                      )}
                       href="https://pf.kakao.com/_cpdEX"
                       rel="noreferrer"
                       target="_blank"
@@ -71,7 +88,7 @@ export default function ReservationPage() {
                       >
                         <path d="M12 3C6.48 3 2 6.48 2 10.8c0 2.7 1.78 5.07 4.45 6.43-.18.6-1.05 3.42-1.08 3.6 0 0-.02.18.1.24.12.07.27.02.27.02.18-.03 3.4-2.22 3.97-2.6.74.1 1.5.16 2.29.16 5.52 0 10-3.48 10-7.85S17.52 3 12 3z" />
                       </svg>
-                      <span>카카오톡 채널</span>
+                      <span className="truncate">카카오톡 채널</span>
                     </a>
                   </div>
                 )}


### PR DESCRIPTION
### 예약상담 신청안내에 홈페이지 상담신청 유도 링크 추가
- 전화랑 카카오톡 신청말고 홈페이지 예약상담도 더 많이 하도록 유도 링크 화면 상단에 추가

### 보안성 개선
- 예약상담 과정에서 비회원/회원이 입력하는 핸드폰번호는 관리자/본인 외 크롤링 및 UI에서 볼 수 없도록 서버 단계에서 권한 체크 후 마스킹 처리