### PR TITLE
refactor: 회원·비회원 후기 생성 로직 분리 및 연락처 저장

### DIFF
--- a/__test__/reviewCreateRoute.test.ts
+++ b/__test__/reviewCreateRoute.test.ts
@@ -1,12 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { adminSet, webSetDoc } = vi.hoisted(() => ({
+const { adminSet, webSetDoc, cookieGet, verifyIdToken, userGet } = vi.hoisted(() => ({
   adminSet: vi.fn(),
   webSetDoc: vi.fn(),
+  cookieGet: vi.fn(),
+  verifyIdToken: vi.fn(),
+  userGet: vi.fn(),
 }));
 
 vi.mock('next/headers', () => ({
-  cookies: vi.fn().mockResolvedValue({ get: vi.fn().mockReturnValue(undefined) }),
+  cookies: vi.fn().mockResolvedValue({ get: cookieGet }),
 }));
 
 vi.mock('next/cache', () => ({
@@ -14,12 +17,12 @@ vi.mock('next/cache', () => ({
 }));
 
 vi.mock('firebase-admin/auth', () => ({
-  getAuth: vi.fn(),
+  getAuth: vi.fn(() => ({ verifyIdToken })),
 }));
 
 vi.mock('firebase-admin/firestore', () => ({
   getFirestore: vi.fn(() => ({
-    collection: vi.fn(() => ({
+    collection: vi.fn((collectionName: string) => ({
       where: vi.fn(() => ({
         where: vi.fn(() => ({
           where: vi.fn(() => ({
@@ -29,7 +32,10 @@ vi.mock('firebase-admin/firestore', () => ({
           })),
         })),
       })),
-      doc: vi.fn(() => ({ set: adminSet })),
+      doc: vi.fn(() => ({
+        set: adminSet,
+        ...(collectionName === 'users' ? { get: userGet } : {}),
+      })),
     })),
   })),
 }));
@@ -67,6 +73,9 @@ describe('POST /api/review/create', () => {
   beforeEach(() => {
     adminSet.mockReset().mockResolvedValue(undefined);
     webSetDoc.mockReset().mockRejectedValue(new Error('permission-denied'));
+    cookieGet.mockReset().mockReturnValue(undefined);
+    verifyIdToken.mockReset().mockResolvedValue({ uid: 'member-uid' });
+    userGet.mockReset().mockResolvedValue({ data: () => ({ isDeleted: false, phoneNumber: '01099998888' }) });
   });
 
   it('전화 인증을 완료한 비회원 후기를 Admin Firestore로 저장한다', async () => {
@@ -92,5 +101,58 @@ describe('POST /api/review/create', () => {
       message: '리뷰가 성공적으로 작성되었습니다.',
       docId: 'review-id',
     });
+  });
+
+  it('회원 후기는 계정에 등록된 phoneNumber를 저장한다', async () => {
+    cookieGet.mockReturnValue({ value: 'member-token' });
+
+    const request = new Request('http://localhost/api/review/create', {
+      method: 'POST',
+      body: JSON.stringify({
+        title: '제목',
+        name: '작성자',
+        franchisee: '수원점',
+        htmlString: '<p>후기</p>',
+        docId: 'member-review-id',
+        images: null,
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(adminSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'member-uid',
+        phoneNumber: '01099998888',
+      }),
+    );
+  });
+
+  it.each(['', null])('회원의 phoneNumber가 %j여도 빈 문자열로 저장하고 후기 작성을 허용한다', async phoneNumber => {
+    cookieGet.mockReturnValue({ value: 'member-token' });
+    userGet.mockResolvedValue({ data: () => ({ isDeleted: false, phoneNumber }) });
+
+    const request = new Request('http://localhost/api/review/create', {
+      method: 'POST',
+      body: JSON.stringify({
+        title: '제목',
+        name: '작성자',
+        franchisee: '수원점',
+        htmlString: '<p>후기</p>',
+        docId: 'member-review-id',
+        images: null,
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(adminSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'member-uid',
+        phoneNumber: '',
+      }),
+    );
   });
 });

--- a/app/api/review/create/guestCreate.ts
+++ b/app/api/review/create/guestCreate.ts
@@ -1,0 +1,54 @@
+import { getFirestore as getAdminFirestore } from 'firebase-admin/firestore';
+
+import { firebaseAdminApp } from '@/src/shared/config/firebase-admin';
+import { hashPhoneNumber } from '@/src/shared/lib/hashPhoneNumber';
+import { verifyPhoneIdToken } from '@/src/shared/lib/verifyPhoneIdToken';
+import { typedJson } from '@/src/shared/utils';
+
+import type { IReviewPost, IReviewResponseBody } from './lib';
+import { saveReview } from './lib';
+
+const DUPLICATE_SUBMISSION_MESSAGE = '동일한 대리점에는 24시간 내 1회만 후기를 작성할 수 있습니다.';
+
+export async function createGuestReview(body: IReviewPost) {
+  const { franchisee, phoneIdToken } = body;
+
+  if (!phoneIdToken) {
+    return typedJson<IReviewResponseBody>(
+      { response: 'ng', message: '휴대폰 인증이 필요합니다.', docId: '' },
+      { status: 401 },
+    );
+  }
+
+  const verifyResult = await verifyPhoneIdToken(phoneIdToken);
+  if (!verifyResult.ok) {
+    return typedJson<IReviewResponseBody>(
+      { response: 'ng', message: '휴대폰 인증에 실패했습니다.', docId: '' },
+      { status: 401 },
+    );
+  }
+
+  const phoneHash = hashPhoneNumber(verifyResult.phoneNumber);
+  const db = getAdminFirestore(firebaseAdminApp);
+  const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const dedupSnap = await db
+    .collection('reviews')
+    .where('phoneHash', '==', phoneHash)
+    .where('franchisee', '==', franchisee)
+    .where('createdAt', '>=', twentyFourHoursAgo)
+    .limit(1)
+    .get();
+
+  if (!dedupSnap.empty) {
+    return typedJson<IReviewResponseBody>(
+      { response: 'ng', message: DUPLICATE_SUBMISSION_MESSAGE, docId: '' },
+      { status: 409 },
+    );
+  }
+
+  return saveReview(body, {
+    userId: null,
+    phoneNumber: verifyResult.phoneNumber,
+    phoneHash,
+  });
+}

--- a/app/api/review/create/lib.ts
+++ b/app/api/review/create/lib.ts
@@ -1,0 +1,61 @@
+import { getFirestore as getAdminFirestore } from 'firebase-admin/firestore';
+import { revalidatePath } from 'next/cache';
+
+import { firebaseAdminApp } from '@/src/shared/config/firebase-admin';
+import { applyReviewImageSrcs } from '@/src/shared/lib/applyReviewImageSrcs';
+import { typedJson } from '@/src/shared/utils';
+
+export interface IReviewPost {
+  title: string;
+  name: string;
+  franchisee: string;
+  htmlString: string;
+  docId: string;
+  images: { key: string; url: string }[] | null;
+  phoneIdToken?: string;
+}
+
+export interface IReviewResponseBody {
+  response: 'ng' | 'ok';
+  message: string;
+  docId: string;
+}
+
+interface IReviewOwner {
+  userId: string | null;
+  phoneNumber: string;
+  phoneHash: string | null;
+}
+
+export async function saveReview(body: IReviewPost, owner: IReviewOwner) {
+  const { title, name, franchisee, htmlString, docId, images } = body;
+  const { imageSrcAppliedHtmlString, thumbnailUrl } = applyReviewImageSrcs(htmlString, images);
+  const db = getAdminFirestore(firebaseAdminApp);
+
+  try {
+    await db.collection('reviews').doc(docId).set({
+      thumbnail: thumbnailUrl,
+      title,
+      name,
+      franchisee,
+      ...owner,
+      htmlString: imageSrcAppliedHtmlString,
+      isPinned: false,
+      pinnedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    revalidatePath('/review');
+    return typedJson<IReviewResponseBody>(
+      { response: 'ok', message: '리뷰가 성공적으로 작성되었습니다.', docId },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error('Error creating review post:', error);
+    return typedJson<IReviewResponseBody>(
+      { response: 'ng', message: '리뷰 작성에 실패했습니다.', docId },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/review/create/route.ts
+++ b/app/api/review/create/route.ts
@@ -1,174 +1,24 @@
-import { getAuth as getAdminAuth } from 'firebase-admin/auth';
-import { getFirestore as getAdminFirestore } from 'firebase-admin/firestore';
-import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 
-import { firebaseAdminApp } from '@/src/shared/config/firebase-admin';
-import { applyReviewImageSrcs } from '@/src/shared/lib/applyReviewImageSrcs';
-import { hashPhoneNumber } from '@/src/shared/lib/hashPhoneNumber';
-import { verifyPhoneIdToken } from '@/src/shared/lib/verifyPhoneIdToken';
 import { typedJson } from '@/src/shared/utils';
 
-interface IReviewPost {
-  title: string;
-  name: string;
-  franchisee: string;
-  htmlString: string;
-  docId: string;
-  images: { key: string; url: string }[] | null;
-  phoneIdToken?: string;
-}
-
-interface IResponseBody {
-  response: 'ng' | 'ok';
-  message: string;
-  docId: string;
-}
-
-const DUPLICATE_SUBMISSION_MESSAGE = '동일한 대리점에는 24시간 내 1회만 후기를 작성할 수 있습니다.';
+import { createGuestReview } from './guestCreate';
+import type { IReviewPost, IReviewResponseBody } from './lib';
+import { createUserReview } from './userCreate';
 
 export async function POST(req: Request) {
   const body = (await req.json()) as IReviewPost;
   const { title, name, franchisee, htmlString } = body;
+
   if (!title || !htmlString || !name || !franchisee) {
-    return typedJson<IResponseBody>(
+    return typedJson<IReviewResponseBody>(
       { response: 'ng', message: '필수로 입력해야하는 필드를 입력해주세요.', docId: '' },
       { status: 400 },
     );
   }
 
-  // 회원인지 확인
   const cookieStore = await cookies();
   const accessToken = cookieStore.get('accessToken');
 
-  if (!accessToken) {
-    return createGuestReviewPost(body);
-  }
-
-  try {
-    const { uid } = await getAdminAuth(firebaseAdminApp).verifyIdToken(accessToken.value);
-
-    // 탈퇴한 유저인지 확인
-    const db = getAdminFirestore(firebaseAdminApp);
-    const userDocSnap = await db.collection('users').doc(uid).get();
-    const targetUserData = userDocSnap.data();
-    if (targetUserData?.isDeleted) {
-      return typedJson<IResponseBody>(
-        {
-          response: 'ng',
-          message: '탈퇴한 유저는 리뷰를 작성할 수 없습니다.',
-          docId: '',
-        },
-        { status: 403 },
-      );
-    }
-
-    return createReviewPost(uid, body);
-  } catch (error) {
-    if (error != null && typeof error === 'object' && 'code' in error && error.code === 'auth/id-token-expired') {
-      return typedJson<IResponseBody>({ response: 'ng', message: 'expired', docId: '' }, { status: 401 });
-    }
-
-    console.error('Error verifying token:', error);
-    return typedJson<IResponseBody>({ response: 'ng', message: 'Unauthorized', docId: '' }, { status: 401 });
-  }
+  return accessToken ? createUserReview(body, accessToken.value) : createGuestReview(body);
 }
-
-const createReviewPost = async (uid: string, body: IReviewPost) => {
-  const { title, name, franchisee, htmlString, docId, images } = body;
-  const { imageSrcAppliedHtmlString, thumbnailUrl } = applyReviewImageSrcs(htmlString, images);
-
-  const db = getAdminFirestore(firebaseAdminApp);
-
-  try {
-    await db.collection('reviews').doc(docId).set({
-      thumbnail: thumbnailUrl,
-      title,
-      name,
-      franchisee,
-      userId: uid,
-      phoneNumber: null,
-      phoneHash: null,
-      htmlString: imageSrcAppliedHtmlString,
-      isPinned: false,
-      pinnedAt: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
-
-    revalidatePath(`/review`);
-    return typedJson<IResponseBody>(
-      { response: 'ok', message: '리뷰가 성공적으로 작성되었습니다.', docId },
-      { status: 200 },
-    );
-  } catch (error) {
-    console.error('Error creating review post:', error);
-    return typedJson<IResponseBody>({ response: 'ng', message: '리뷰 작성에 실패했습니다.', docId }, { status: 500 });
-  }
-};
-
-const createGuestReviewPost = async (body: IReviewPost) => {
-  const { title, name, franchisee, htmlString, docId, images, phoneIdToken } = body;
-
-  if (!phoneIdToken) {
-    return typedJson<IResponseBody>(
-      { response: 'ng', message: '휴대폰 인증이 필요합니다.', docId: '' },
-      { status: 401 },
-    );
-  }
-
-  const verifyResult = await verifyPhoneIdToken(phoneIdToken);
-  if (!verifyResult.ok) {
-    return typedJson<IResponseBody>(
-      { response: 'ng', message: '휴대폰 인증에 실패했습니다.', docId: '' },
-      { status: 401 },
-    );
-  }
-
-  const phoneHash = hashPhoneNumber(verifyResult.phoneNumber);
-
-  const db = getAdminFirestore(firebaseAdminApp);
-
-  const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
-  const dedupSnap = await db
-    .collection('reviews')
-    .where('phoneHash', '==', phoneHash)
-    .where('franchisee', '==', franchisee)
-    .where('createdAt', '>=', twentyFourHoursAgo)
-    .limit(1)
-    .get();
-  if (!dedupSnap.empty) {
-    return typedJson<IResponseBody>(
-      { response: 'ng', message: DUPLICATE_SUBMISSION_MESSAGE, docId: '' },
-      { status: 409 },
-    );
-  }
-
-  const { imageSrcAppliedHtmlString, thumbnailUrl } = applyReviewImageSrcs(htmlString, images);
-
-  try {
-    await db.collection('reviews').doc(docId).set({
-      thumbnail: thumbnailUrl,
-      title,
-      name,
-      franchisee,
-      userId: null,
-      phoneNumber: verifyResult.phoneNumber,
-      phoneHash,
-      htmlString: imageSrcAppliedHtmlString,
-      isPinned: false,
-      pinnedAt: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
-
-    revalidatePath(`/review`);
-    return typedJson<IResponseBody>(
-      { response: 'ok', message: '리뷰가 성공적으로 작성되었습니다.', docId },
-      { status: 200 },
-    );
-  } catch (error) {
-    console.error('Error creating guest review post:', error);
-    return typedJson<IResponseBody>({ response: 'ng', message: '리뷰 작성에 실패했습니다.', docId }, { status: 500 });
-  }
-};

--- a/app/api/review/create/userCreate.ts
+++ b/app/api/review/create/userCreate.ts
@@ -1,0 +1,34 @@
+import { getAuth as getAdminAuth } from 'firebase-admin/auth';
+import { getFirestore as getAdminFirestore } from 'firebase-admin/firestore';
+
+import { firebaseAdminApp } from '@/src/shared/config/firebase-admin';
+import { typedJson } from '@/src/shared/utils';
+
+import type { IReviewPost, IReviewResponseBody } from './lib';
+import { saveReview } from './lib';
+
+export async function createUserReview(body: IReviewPost, accessToken: string) {
+  try {
+    const { uid } = await getAdminAuth(firebaseAdminApp).verifyIdToken(accessToken);
+    const db = getAdminFirestore(firebaseAdminApp);
+    const userDocSnap = await db.collection('users').doc(uid).get();
+    const userData = userDocSnap.data();
+
+    if (userData?.isDeleted) {
+      return typedJson<IReviewResponseBody>(
+        { response: 'ng', message: '탈퇴한 유저는 리뷰를 작성할 수 없습니다.', docId: '' },
+        { status: 403 },
+      );
+    }
+
+    const phoneNumber = userData?.phoneNumber ?? '';
+    return saveReview(body, { userId: uid, phoneNumber, phoneHash: null });
+  } catch (error) {
+    if (error != null && typeof error === 'object' && 'code' in error && error.code === 'auth/id-token-expired') {
+      return typedJson<IReviewResponseBody>({ response: 'ng', message: 'expired', docId: '' }, { status: 401 });
+    }
+
+    console.error('Error verifying token:', error);
+    return typedJson<IReviewResponseBody>({ response: 'ng', message: 'Unauthorized', docId: '' }, { status: 401 });
+  }
+}


### PR DESCRIPTION
### 개선사항
- 후기 생성 로직을 회원, 비회원, 공통 저장 모듈로 분리
- 회원 리뷰에 계정 연락처 저장
- 연락처가 없는 회원도 빈 문자열로 저장하고 작성 허용
- 회원 연락처 저장 및 빈 값 처리 회귀 테스트 추가